### PR TITLE
Fix the ruby 3.2 warning around undeffing t_data types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Add Ruby 3.0 to the cross compile list
 * Fix segfault when asking if client was dead after closing it. Fixes #519.
 * Fix Gem installation on Windows by adding default freetds msys path. Fixes #522
+* Fix undef warning around T_DATA classes mentioned in #515, fixes #515
 
 ## 2.1.5
 

--- a/ext/tiny_tds/result.c
+++ b/ext/tiny_tds/result.c
@@ -582,8 +582,9 @@ void init_tinytds_result() {
   /* Data Classes */
   cKernel = rb_const_get(rb_cObject, rb_intern("Kernel"));
   cDate = rb_const_get(rb_cObject, rb_intern("Date"));
-  /* Define TinyTds::Result */
+  /* Define TinyTds::Result and undefine alloc per ruby 3.2 */
   cTinyTdsResult = rb_define_class_under(mTinyTds, "Result", rb_cObject);
+  rb_undef_alloc_func(cTinyTdsResult);
   /* Define TinyTds::Result Public Methods */
   rb_define_method(cTinyTdsResult, "fields", rb_tinytds_result_fields, 0);
   rb_define_method(cTinyTdsResult, "each", rb_tinytds_result_each, -1);


### PR DESCRIPTION
Ruby 3.2 does this automatically and it results in a warning, this will apparently raise an error in future versions of ruby so might as well resolve it now.